### PR TITLE
Disable polyfill for Promise.prototype.finally

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -22,7 +22,7 @@ export default class extends Document {
           />
           <link
             as="script"
-            href="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver%2CPromise.prototype.finally"
+            href="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"
             rel="preload"
           />
         </Head>
@@ -42,7 +42,7 @@ export default class extends Document {
             href="https://fonts.googleapis.com/css?family=Material+Icons"
             rel="stylesheet"
           />
-          <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver%2CPromise.prototype.finally" />
+          <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver" />
 
           <NextScript />
         </body>


### PR DESCRIPTION
Because it conflicts with polyfill for `Promise` of Next.js, remove polyfill of Polyfills.io.
